### PR TITLE
feature: add generic development VM

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,51 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.require_version '>=1.7.4'
+
+ssh_pub_key_path = File.expand_path(ENV['SSH_PUBLIC_KEY'] || '~/.ssh/id_rsa.pub')
+ssh_pub_key = File.exist?(ssh_pub_key_path) ? File.read(ssh_pub_key_path) : ''
+ssh_pub_key_script = <<EOF
+echo "copying host SSH pubkey into vagrant"
+cat >> ~vagrant/.ssh/authorized_keys <<EOT
+#{ssh_pub_key}
+EOT
+EOF
+
+vagrant_profile_path = File.expand_path('~/.vagrant_profile')
+vagrant_profile = File.exist?(vagrant_profile_path) ? File.read(vagrant_profile_path) : ''
+vagrant_profile_script = <<EOF
+echo "copying vagrant_profile into vagrant"
+cat > ~vagrant/.vagrant_profile << EOT
+#{vagrant_profile}
+EOT
+EOF
+
+Vagrant.configure(2) do |config|
+  config.vm.box = 'hashicorp/precise64'
+
+  config.vm.network :private_network, ip: '01.17.19.91'
+
+  # skip creating a local VM specific ssh key
+  config.ssh.insert_key = false
+  config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder File.expand_path('~/programs'), '/programs'
+
+  config.vm.provider "virtualbox" do |vb|
+    # Customize the amount of memory on the VM:
+    vb.memory = 2048
+    vb.cpus = 2
+    vb.auto_nat_dns_proxy = false
+    vb.customize ['modifyvm', :id, '--natdnsproxy1', 'off']
+    vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+  end
+
+  config.vm.provision :shell, :inline => ssh_pub_key_script
+  config.vm.provision :shell, :inline => vagrant_profile_script
+  config.vm.provision :shell, :path => './dev.sh'
+  config.vm.provision :shell, :path => './docker.sh'
+end

--- a/vagrant/bash_profile
+++ b/vagrant/bash_profile
@@ -1,0 +1,10 @@
+. ~/.bashrc
+. /etc/bash_completion
+. ~/.vagrant_profile
+
+LIGHT_GREEN="\[\033[1;32m\]"
+YELLOW="\[\033[0;33m\]"
+BLUE="\[\033[0;34m\]"
+LIGHT_CYAN="\[\033[1;36m\]"
+WHITE="\[\033[00m\]"
+export PS1="$BLUE[$LIGHT_GREEN\u$YELLOW@$LIGHT_GREEN\H$LIGHT_CYAN \w$BLUE]$YELLOW\$(__git_ps1 \"(%s)\")$WHITE\$ "

--- a/vagrant/dev.sh
+++ b/vagrant/dev.sh
@@ -1,0 +1,26 @@
+# install basic development dependencies
+apt-get update
+apt-get install -y build-essential \
+  curl \
+  ack \
+  python-software-properties \
+  python \
+  g++ \
+  make \
+  git \
+  python-pip \
+  vim
+
+# setup vagrant user 
+echo "setting up vagrant user"
+cat /vagrant/bash_profile > ~vagrant/.bash_profile
+touch ~vagrant/.hush_login
+
+# setup root user
+echo "setting up root user"
+mkdir -p /root/.ssh/
+touch /root/.ssh/authorized_keys
+cat ~vagrant/.ssh/authorized_keys >> /root/.ssh/authorized_keys
+cat /vagrant/bash_profile > ~root/.bash_profile
+cat ~vagrant/.vagrant_profile > ~root/.vagrant_profile
+touch ~/.hush_login

--- a/vagrant/docker.sh
+++ b/vagrant/docker.sh
@@ -1,0 +1,14 @@
+# add docker apt-source
+apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+cat > /etc/apt/sources.list.d/docker.list << EOT
+  deb https://apt.dockerproject.org/repo ubuntu-precise main
+EOT
+apt-get update
+apt-cache policy docker-engine
+
+# install docker-engine and start docker daemon
+apt-get install -y docker-engine
+
+# install docker-compose
+pip install functools32
+pip install docker-compose


### PR DESCRIPTION
This is a super simple, basic VM that is useful for the types of services I tend to build in my spare time.

This sets up a basic VM which configures a few things

* docker
* docker-compose
* some basic apt-get utilities
* vagrant_profile
* mount `$HOME/programs` into the VM

By creating a `$HOME/.vagrant_profile` on your host machine, you can create a custom boot up script for the `vagrant` and `root` users in this VM.